### PR TITLE
(SIMP-3911) Selinux context getting overwritten

### DIFF
--- a/build/selinux/simp-environment.fc
+++ b/build/selinux/simp-environment.fc
@@ -1,1 +1,27 @@
-/var/simp(/.*)?     system_u:object_r:puppet_var_lib_t:s0
+#IN order for puppetserver to access files it needs a puppet_var_lib_t context.
+/var/simp(/.*)?                                                                                                     system_u:object_r:puppet_var_lib_t:s0
+/var/simp/(?!environments)[^/]+(/.*)?                                                                               system_u:object_r:puppet_var_lib_t:s0
+/var/simp/environments                                                                                              system_u:object_r:puppet_var_lib_t:s0
+/var/simp/environments/[^/]+                                                                                        system_u:object_r:puppet_var_lib_t:s0
+#Anything in an environment not under rsync should have puppet server access
+/var/simp/environments/[^/]+/(?!rsync)[^/]+(/.*)?                                                                   system_u:object_r:puppet_var_lib_t:s0
+# Rsysnc files need to keep there context and should not default to var or puppet defaults.
+# The following line is meant to stop those defaults.  This means anything not set
+# in the following lines will not be affected by a selinux relabel.
+/var/simp/environments/[^/]+/rsync(/.*)                                                                             <<none>>
+/var/simp/environments/[^/]+/rsync/RedHat/Global/apache/www(/.*)?                                                   system_u:object_r:httpd_sys_content_t:s0
+/var/simp/environments/[^/]+/rsync/RedHat/Global/dhcpd(/.*)?                                                        system_u:object_r:dhcp_etc_t:s0
+/var/simp/environments/[^/]+/rsync/RedHat/Global/tftpboot(/.*)?                                                     system_u:object_r:tftpdir_t:s0
+/var/simp/environments/[^/]+/rsync/RedHat/Global/freeradius(/.*)?                                                   system_u:object_r:radiusd_etc_t:s0
+/var/simp/environments/[^/]+/rsync/RedHat/Global/snmp/mibs(/.*)?                                                    system_u:object_r:snmpd_var_lib_t:s0
+/var/simp/environments/[^/]+/rsync/RedHat/Global/snmp/dlmod(/.*)?                                                   system_u:object_r:snmpd_exec_t:s0
+/var/simp/environments/[^/]+/rsync/Global/mcafee(/.*)?                                                              system_u:object_r:antivirus_db_t:s0
+/var/simp/environments/[^/]+/rsync/[^/]+/[^/]+/bind_dns/[^/]+/named                                                 system_u:object_r:named_conf_t:s0
+/var/simp/environments/[^/]+/rsync/[^/]+/[^/]+/bind_dns/[^/]+/named/etc                                             system_u:object_r:etc_t:s0
+/var/simp/environments/[^/]+/rsync/[^/]+/[^/]+/bind_dns/[^/]+/named/etc/rndc.key                                    system_u:object_r:dnssec_t:s0
+/var/simp/environments/[^/]+/rsync/[^/]+/[^/]+/bind_dns/[^/]+/named/etc/.+                                          system_u:object_r:named_conf_t:s0
+/var/simp/environments/[^/]+/rsync/[^/]+/[^/]+/bind_dns/[^/]+/named/var(/.*)?                                       system_u:object_r:var_t:s0
+/var/simp/environments/[^/]+/rsync/[^/]+/[^/]+/bind_dns/[^/]+/named/var/named                                       system_u:object_r:named_zone_t:s0
+/var/simp/environments/[^/]+/rsync/[^/]+/[^/]+/bind_dns/[^/]+/named/var/named/(slaves|data)(/.*)?                   system_u:object_r:named_cache_t:s0
+/var/simp/environments/[^/]+/rsync/[^/]+/[^/]+/bind_dns/[^/]+/named/var/named/.+.(zone|local|zero|broadcast|root)   system_u:object_r:named_zone_t:s0
+/var/simp/environments/[^/]+/rsync/[^/]+/[^/]+/bind_dns/[^/]+/named/var/named/(forward|reverse)(/.*)?               system_u:object_r:named_zone_t:s0

--- a/build/selinux/simp-environment.fc
+++ b/build/selinux/simp-environment.fc
@@ -1,10 +1,5 @@
 #IN order for puppetserver to access files it needs a puppet_var_lib_t context.
 /var/simp(/.*)?                                                                                                     system_u:object_r:puppet_var_lib_t:s0
-/var/simp/(?!environments)[^/]+(/.*)?                                                                               system_u:object_r:puppet_var_lib_t:s0
-/var/simp/environments                                                                                              system_u:object_r:puppet_var_lib_t:s0
-/var/simp/environments/[^/]+                                                                                        system_u:object_r:puppet_var_lib_t:s0
-#Anything in an environment not under rsync should have puppet server access
-/var/simp/environments/[^/]+/(?!rsync)[^/]+(/.*)?                                                                   system_u:object_r:puppet_var_lib_t:s0
 # Rsysnc files need to keep there context and should not default to var or puppet defaults.
 # The following line is meant to stop those defaults.  This means anything not set
 # in the following lines will not be affected by a selinux relabel.
@@ -16,6 +11,7 @@
 /var/simp/environments/[^/]+/rsync/RedHat/Global/snmp/mibs(/.*)?                                                    system_u:object_r:snmpd_var_lib_t:s0
 /var/simp/environments/[^/]+/rsync/RedHat/Global/snmp/dlmod(/.*)?                                                   system_u:object_r:snmpd_exec_t:s0
 /var/simp/environments/[^/]+/rsync/Global/mcafee(/.*)?                                                              system_u:object_r:antivirus_db_t:s0
+/var/simp/environments/[^/]+/rsync/Global/clamav(/.*)?                                                              system_u:object_r:antivirus_db_t:s0
 /var/simp/environments/[^/]+/rsync/[^/]+/[^/]+/bind_dns/[^/]+/named                                                 system_u:object_r:named_conf_t:s0
 /var/simp/environments/[^/]+/rsync/[^/]+/[^/]+/bind_dns/[^/]+/named/etc                                             system_u:object_r:etc_t:s0
 /var/simp/environments/[^/]+/rsync/[^/]+/[^/]+/bind_dns/[^/]+/named/etc/rndc.key                                    system_u:object_r:dnssec_t:s0

--- a/build/selinux/simp-environment.te
+++ b/build/selinux/simp-environment.te
@@ -1,4 +1,4 @@
-module simp-environment 1.0;
+module simp-environment 2.0;
 
 require {
   type puppet_var_lib_t;

--- a/build/simp-environment.spec
+++ b/build/simp-environment.spec
@@ -268,9 +268,14 @@ fi
 
 %changelog
 * Thu Oct 26 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.2.5-0
-- included simp-rsync selinux policy
-- update simp-environment selinux policy to ensure rsync
+- selinux policy in module simp-environment was changing settings on rsync files not in the
+  simp environment and removing their selinux context.  This caused DNS, DHCP to fail 
+  if they were running in an enviroment by a name other then simp.
+- moved selinux policy to simp-environment module and had simp rsync require this module
+  so the selinux policy for /var/simp directory would be in one spot.
   file contexts are not overwritten by it.
+- updated the policy so it would explicitly set the context for files in simp environment and
+  not overwrite settings that were not explicitly set.
 
 * Fri Sep 22 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.2.4-0
 - Fix changelog/version mismatch which resulted in the release of

--- a/build/simp-environment.spec
+++ b/build/simp-environment.spec
@@ -1,4 +1,31 @@
-%global selinux_policyver %(%{__sed} -e %'s,.*selinux-policy-\\([^/]*\\)/.*,\\1,' %/usr/share/selinux/devel/policyhelp 2>/dev/null || echo 0.0.0)
+# policycoreutils_version and selinux_policy_version are specifically set
+# to the *earliest* version of these packages present in these major releases.
+#
+# This is required since SELinux policies are forward compatible during a major
+# release but not necessarily backwards compatible and we want to ensure
+# maximum package compatibility.
+#
+# Use environment variable SIMP_ENV_NO_SELINUX_DEPS to ignore this
+# and use the latest.  (This is good when building test ISOs that
+# from a local environment, instead of a docker build, where a later
+# version of selinux is installed.)
+%define ignore_selinux_reqs %{getenv:SIMP_ENV_NO_SELINUX_DEPS}
+
+# Only run the following if the environment variable is *not* defined
+%if "%{ignore_selinux_reqs}" == ""
+  %if 0%{?rhel} == 6 || 0%{?rhel} == 7
+    %if 0%{?rhel} == 6
+      %global policycoreutils_version 2.0.83
+      %global selinux_policy_version 3.7.19
+    %endif
+
+    %if 0%{?rhel} == 7
+      %global policycoreutils_version 2.2.5
+      %global selinux_policy_version 3.12.1
+    %endif
+  %endif
+%endif
+
 %global selinux_variants targeted
 
 %define selinux_policy_short simp-environment
@@ -6,7 +33,7 @@
 
 Summary: The SIMP Environment Scaffold
 Name: simp-environment
-Version: 6.2.4
+Version: 6.2.5
 Release: 0
 License: Apache License 2.0
 Group: Applications/System
@@ -26,13 +53,39 @@ Requires(post): coreutils
 Requires(post): glibc-common
 Requires(post): pam
 Requires(post): libsemanage
-Requires(post): selinux-policy >= %{selinux_policyver}
-Requires(post): selinux-policy-targeted >= %{selinux_policyver}
+%if 0%{?selinux_policy_version:1}
+Requires(post): selinux-policy >= %{selinux_policy_version}
+Requires(post): selinux-policy-targeted >= %{selinux_policy_version}
+%else
+Requires(post): selinux-policy
+Requires(post): selinux-policy-targeted
+%endif
+
 Requires(postun): policycoreutils
 BuildRequires: selinux-policy-targeted
-%if "%{?rhel}%{!?rhel:0}" > "6"
+%if 0%{?selinux_policy_version:1}
+BuildRequires: policycoreutils == %{policycoreutils_version}
+BuildRequires: policycoreutils-python == %{policycoreutils_version}
+BuildRequires: selinux-policy == %{selinux_policy_version}
+BuildRequires: selinux-policy-devel == %{selinux_policy_version}
+  %if 0%{?rhel} == 7
+BuildRequires: policycoreutils-devel == %{policycoreutils_version}
+  %endif
+%else
+BuildRequires: policycoreutils
+BuildRequires: policycoreutils-python
+BuildRequires: selinux-policy
 BuildRequires: selinux-policy-devel
+  %if 0%{?rhel} == 7
+BuildRequires: policycoreutils-devel
+BuildRequires: selinux-policy-targeted
+  %endif
 %endif
+
+
+#%if "%{?rhel}%{!?rhel:0}" > "6"
+#BuildRequires: selinux-policy-devel
+#%endif
 Provides: simp-bootstrap = %{version}-%{release}
 Provides: simp_bootstrap = %{version}-%{release}
 Obsoletes: simp-bootstrap < %{version}-%{release}
@@ -112,6 +165,8 @@ cd -
 PATH=/opt/puppetlabs/bin:$PATH
 export PATH
 
+# Build an load policy to set selinux context to enable puppet
+# to read from /var/simp directories.
 /usr/sbin/semodule -n -i %{_datadir}/selinux/packages/%{selinux_policy}
 if /usr/sbin/selinuxenabled; then
   /usr/sbin/load_policy
@@ -212,13 +267,18 @@ fi
 /usr/local/sbin/simp_rpm_helper --rpm_dir=%{prefix} --rpm_section='postun' --rpm_status=$1 --preserve --target_dir='.'
 
 %changelog
+* Thu Oct 26 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.2.5-0
+- included simp-rsync selinux policy
+- update simp-environment selinux policy to ensure rsync
+  file contexts are not overwritten by it.
+
 * Fri Sep 22 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.2.4-0
 - Fix changelog/version mismatch which resulted in the release of
   a 6.2.1 tag for which the RPM version was erroneously 6.2.3.
-  
+
 * Fri Sep 22 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.2.3-0
 - Version erroneously tagged as 6.2.1.
-  
+
 * Fri Sep 22 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.2.2-0
 - Untagged version.
 


### PR DESCRIPTION
  - update selinux module file contexts so user
    rsync environments context would not get
    overwritten

SIMP-3920 #close
SIMP-3921 #close