### PR TITLE
(SIMP-4049) Collect local puppetserver logs

### DIFF
--- a/build/simp-environment.spec
+++ b/build/simp-environment.spec
@@ -33,7 +33,7 @@
 
 Summary: The SIMP Environment Scaffold
 Name: simp-environment
-Version: 6.2.6
+Version: 6.2.7
 Release: 0
 License: Apache License 2.0
 Group: Applications/System
@@ -287,6 +287,10 @@ fi
 /usr/local/sbin/simp_rpm_helper --rpm_dir=%{prefix} --rpm_section='postun' --rpm_status=$1 --preserve --target_dir='.'
 
 %changelog
+* Fri Nov 17 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.2.7-0
+- Enable the UDP localhost rsyslog server on the puppetserver to capture
+  messages from the puppet services for processing and forwarding
+
 * Fri Nov 03 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.2.6-0
 - Ensure that FakeCA works properly with Puppet Enterprise
 - Ensure that the RPM installation permissions work properly with Puppet

--- a/environments/simp/hieradata/hosts/puppet.your.domain.yaml
+++ b/environments/simp/hieradata/hosts/puppet.your.domain.yaml
@@ -43,7 +43,22 @@ simp_options::tcpwrappers: true
 # Allow the backup SIMP user, local only to this system
 simp::server::allow_simp_user: true
 
+# Ensure that the puppetserver's logs can be captured by the local system so
+# that they can be forwarded for analysis at a later date.
+#
+# Using a local UDP server allows for a much more reliable collection mechanism
+# than rsyslog file taps and allows for the encryption of log messages.
+#
+# For Puppet Open Source, the logs will be stored in /var/log/puppetserver.log
+# and are collected at the 'warn' level by default. Puppet Enterprise logging
+# settings are not manipulated by SIMP.
+rsyslog::udp_server: true
+rsyslog::udp_listen_address: '127.0.0.1'
+
+# Un-comment this line if using Puppet Open Source and you need the
+# puppetserver messages regarding node compile times, etc...
+# pupmod::master::log_level: INFO
+
 classes:
   - 'simp::server'
   - 'simp::puppetdb'
-


### PR DESCRIPTION
* Ensure that the local puppetserver logs can be collected via UDP by
  rsyslog by default

SIMP-4049 #comment Updated environment defaults
SIMP-4078 #close