### PR TITLE
(SIMP-2780) Prevent RPM uninstall failure in edge case

### DIFF
--- a/build/simp-environment.spec
+++ b/build/simp-environment.spec
@@ -255,7 +255,9 @@ fi
 
 # Needed for migrating the environment data into the codedir for an initial install
 if [ $1 -eq 1 ]; then
-  /usr/local/sbin/simp_rpm_helper --rpm_dir=%{prefix} --rpm_section='post' --rpm_status=$1 --preserve --target_dir='.'
+  if [ -x /usr/local/sbin/simp_rpm_helper ] ; then
+    /usr/local/sbin/simp_rpm_helper --rpm_dir=%{prefix} --rpm_section='post' --rpm_status=$1 --preserve --target_dir='.'
+  fi
 fi
 
 %postun
@@ -268,7 +270,9 @@ if [ $1 -eq 0 ]; then
   fi
 
   # Needed for cleaning up the data from codedir as appropriate for an erase
-  /usr/local/sbin/simp_rpm_helper --rpm_dir=%{prefix} --rpm_section='postun' --rpm_status=$1 --preserve --target_dir='.'
+  if [ -x /usr/local/sbin/simp_rpm_helper ] ; then
+    /usr/local/sbin/simp_rpm_helper --rpm_dir=%{prefix} --rpm_section='postun' --rpm_status=$1 --preserve --target_dir='.'
+  fi
 fi
 
 

--- a/environments/simp/manifests/site.pp
+++ b/environments/simp/manifests/site.pp
@@ -15,7 +15,7 @@ Exec {
 # Set this variable to make use of the different class sets in heiradata/scenarios,
 #   mostly applicable to puppet agents, or, the SIMP server overrides some of these.
 #   * `simp` - compliant and secure
-#   * `simp-lite` - makes use of many of our modules, but doesn't apply
+#   * `simp_lite` - makes use of many of our modules, but doesn't apply
 #        many prohibitive security or compliance features, svckill
 #   * `poss` - only include pupmod by default to configure the agent
 $simp_scenario = 'simp'


### PR DESCRIPTION
Only attempt to run simp_rpm_helper, when it exists.  This extra check
allows the simp-environment RPM to be erased even if, due to some other
unexpected RPM erase failure,  the simp-adapter RPM has been already
been erased and thus, simp_rpm_helper is no longer present.

SIMP-2780 #comment simp-environment fix