### PR TITLE
Added fully qualified path to the puppet binary for the gencerts scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 jobs:
   include:
     - stage: check
-      rvm: 2.4.1
+      rvm: 2.4.4
       script:
         - bundle exec rake syntax
         - bundle exec rake yaml_validate
@@ -28,7 +28,7 @@ jobs:
         - bundle exec rake pkg:create_tag_changelog
 
     - stage: deploy
-      rvm: 2.4.1
+      rvm: 2.4.4
       script:
         - true
       before_deploy:

--- a/FakeCA/gencerts_common.sh
+++ b/FakeCA/gencerts_common.sh
@@ -92,5 +92,5 @@ distribute_ca () {
   fi
 
   chmod -R u+rwX,g+rX,o-rwx $keydist;
-  chown -R root.`puppet config print group 2>/dev/null` $keydist;
+  chown -R root.`/opt/puppetlabs/bin/puppet config print group 2>/dev/null` $keydist;
 }

--- a/build/simp-environment.spec
+++ b/build/simp-environment.spec
@@ -279,7 +279,7 @@ fi
 %changelog
 * Fri Feb 15 2019 Michael Riddle <michael.riddle@onyxpoint.com> - 6.3.1-0
 - If the gencerts scripts are called via sudo, puppet won't be in the path.
-  Added the fully qualified path to the puppet binary to
+  Added the fully qualified path to the puppet binary to remedy this issue.
 
 * Thu Jul 26 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.3.0-0
 - Added a default Hiera 5 hiera.yaml.

--- a/build/simp-environment.spec
+++ b/build/simp-environment.spec
@@ -33,7 +33,7 @@
 
 Summary: The SIMP Environment Scaffold
 Name: simp-environment
-Version: 6.3.0
+Version: 6.3.1
 Release: 0%{?dist}
 License: Apache License 2.0
 Group: Applications/System
@@ -277,6 +277,10 @@ fi
 
 
 %changelog
+* Fri Feb 15 2019 Michael Riddle <michael.riddle@onyxpoint.com> - 6.3.1-0
+- If the gencerts scripts are called via sudo, puppet won't be in the path.
+  Added the fully qualified path to the puppet binary to
+
 * Thu Jul 26 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.3.0-0
 - Added a default Hiera 5 hiera.yaml.
 - Renamed environments/simp/hieradata/ to environments/simp/data/ to support


### PR DESCRIPTION
If the gencerts scripts are called via sudo, puppet won't be in the path. Added the fully qualified path to the puppet binary to resolve this issue.