### PR TITLE
(SIMP-4304) SIMP should not required LDAP by default

### DIFF
--- a/build/simp-environment.spec
+++ b/build/simp-environment.spec
@@ -277,6 +277,13 @@ fi
 
 
 %changelog
+* Tue Apr 09 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.3.1-0
+- `simp_options::ldap` now defaults to `false` in the simp and simp_lite
+  scenarios, because use of LDAP is not required.  This change will
+  is important for sites that do not use LDAP at all or use a different
+  implementation of LDAP that does not match the schemas provided by
+  SIMP.
+
 * Fri Feb 15 2019 Michael Riddle <michael.riddle@onyxpoint.com> - 6.3.1-0
 - If the gencerts scripts are called via sudo, puppet won't be in the path.
   Added the fully qualified path to the puppet binary to remedy this issue.

--- a/environments/simp/data/scenarios/simp.yaml
+++ b/environments/simp/data/scenarios/simp.yaml
@@ -29,7 +29,6 @@ simp_options::auditd: true
 simp_options::clamav: true
 simp_options::firewall: true
 simp_options::haveged: true
-simp_options::ldap: true
 simp_options::logrotate: true
 simp_options::pam: true
 simp_options::pki: simp
@@ -37,6 +36,10 @@ simp_options::sssd: true
 simp_options::stunnel: true
 simp_options::syslog: true
 simp_options::tcpwrappers: true
+
+# This setting is turned off by default because use of LDAP is not
+# required
+simp_options::ldap: false
 
 # Options that are not suggested to be turned on by default:
 simp_options::ipsec: false

--- a/environments/simp/data/scenarios/simp_lite.yaml
+++ b/environments/simp/data/scenarios/simp_lite.yaml
@@ -28,13 +28,16 @@ simp::scenario: 'simp_lite'
 simp_options::auditd: true
 simp_options::clamav: true
 simp_options::haveged: true
-simp_options::ldap: true
 simp_options::logrotate: true
 simp_options::pam: true
 simp_options::pki: simp
 simp_options::sssd: true
 simp_options::stunnel: true
 simp_options::syslog: true
+
+# This setting is turned off by default because use of LDAP is not
+# required
+simp_options::ldap: false
 
 # These settings explicitly turned off
 simp_options::firewall: false


### PR DESCRIPTION
Set `simp_options::ldap` to `false` in the simp and simp_lite
scenarios, because use of LDAP is not required.  This change will
is important for sites that do not use LDAP at all or use a different
implementation of LDAP that does not match the schemas provided by
SIMP.

SIMP-4304 #comment simp-environment-skeleton