### PR TITLE
(SIMP-5312) TCPWrappers deprecated in RHEL8

### DIFF
--- a/build/simp-environment-skeleton.spec
+++ b/build/simp-environment-skeleton.spec
@@ -1,7 +1,7 @@
 Summary: The SIMP Environment Skeleton
 Name: simp-environment-skeleton
-Version: 7.1.0
-Release: 0
+Version: 7.1.1
+Release: 0%{?dist}
 License: Apache License 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -36,6 +36,12 @@ mkdir -p %{buildroot}/%{prefix}/secondary/site_files/pki_files/files/keydist/cac
 
 cp -r environments/* %{buildroot}/%{prefix}
 
+%if 0%{?rhel} <= 7
+  rm %{buildroot}/%{prefix}/puppet/data/hosts/puppet.your.domain.el8.yaml
+%else
+  mv -f %{buildroot}/%{prefix}/puppet/data/hosts/puppet.your.domain.el8.yaml %{buildroot}/%{prefix}/puppet/data/hosts/puppet.your.domain.yaml
+%endif
+
 %clean
 [ "%{buildroot}" != "/" ] && rm -rf %{buildroot}
 
@@ -59,6 +65,8 @@ cp -r environments/* %{buildroot}/%{prefix}
 %{prefix}/puppet/hiera.yaml
 %{prefix}/puppet/data/hosts/puppet.your.domain.yaml
 %{prefix}/puppet/data/hostgroups/default.yaml
+%{prefix}/puppet/data/scenarios/RedHat/8/simp.yaml
+%{prefix}/puppet/data/scenarios/CentOS/8/simp.yaml
 %{prefix}/puppet/data/scenarios/simp.yaml
 %{prefix}/puppet/data/scenarios/simp_lite.yaml
 %{prefix}/puppet/data/scenarios/poss.yaml
@@ -80,6 +88,17 @@ cp -r environments/* %{buildroot}/%{prefix}
 %attr(0750,-,-) %{prefix}/secondary/FakeCA/usergen_nopass.sh
 
 %changelog
+* Fri Sep 06 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 7.1.1-0
+- Added OS version directories under the hiera architecture to allow for different
+  settings for different scenarios on different OS.  Since TCP Wrappers was
+  removed from RedHat 8, the setting for simp_options::tcpwrappers is
+  set to false in the simp scenario for RedHat and Centos major version 8.
+- Made the data in the puppet.your.domain.yaml that is installed in the
+  environment skeleton directory specific to the version it is being installed
+  on.  (The only difference at this time is the simp_options::tcpwrappers setting)
+  This makes this rpm distribution specfic and was done to minimized the changes
+  for simp-cli for building new environments.
+
 * Wed Jun 26 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.1.0-0
 - Rename the package to 'simp-environment-skeleton' to more accurately portray
   its purpose.

--- a/environments/puppet/data/hosts/puppet.your.domain.el8.yaml
+++ b/environments/puppet/data/hosts/puppet.your.domain.el8.yaml
@@ -1,0 +1,64 @@
+---
+# This must contain 'trusted_nets' if you want this to cover your base YUM
+# repo services.
+#
+# We don't enable non-TLS connections by default. All SIMP services should now
+# be able to use TLS for all connections.
+simp_apache::conf::ssl::trusted_nets: "%{alias('simp_options::trusted_nets')}"
+
+# We disable the SSL client validation for the Kickstart server. There is no
+# way to validate a default image without embedding a certificate in the image
+# and we are not going to modify the core kickstart image from the vendor.
+#
+# Since this system is, by default, only a kickstart/YUM server with Apache,
+# this will not adversely affect the security posture of the system.
+simp_apache::ssl::sslverifyclient: 'none'
+
+# Make this server a puppetserver
+pupmod::enable_puppet_master: true
+
+# The service name of the Puppet Server service for use with PuppetDB
+#
+# TODO: This should probably be a Fact
+puppetdb::master::config::puppet_service_name: 'puppetserver'
+
+puppetdb::globals::version: 'latest'
+
+# Let pupmod::master::base handle this.
+puppetdb::master::config::restart_puppet: false
+
+### Secure SIMP Options ###
+simp_options::auditd: true
+simp_options::clamav: true
+simp_options::firewall: true
+simp_options::haveged: true
+simp_options::logrotate: true
+simp_options::pam: true
+simp_options::pki: simp
+simp_options::stunnel: true
+simp_options::syslog: true
+# TCP Wrappers was depricated in RHEL 8 so set  the option to false.
+simp_options::tcpwrappers: false
+
+# Allow the backup SIMP user, local only to this system
+simp::server::allow_simp_user: true
+
+# Ensure that the puppetserver's logs can be captured by the local system so
+# that they can be forwarded for analysis at a later date.
+#
+# Using a local UDP server allows for a much more reliable collection mechanism
+# than rsyslog file taps and allows for the encryption of log messages.
+#
+# For Puppet Open Source, the logs will be stored in /var/log/puppetserver.log
+# and are collected at the 'warn' level by default. Puppet Enterprise logging
+# settings are not manipulated by SIMP.
+rsyslog::udp_server: true
+rsyslog::udp_listen_address: '127.0.0.1'
+
+# Un-comment this line if using Puppet Open Source and you need the
+# puppetserver messages regarding node compile times, etc...
+# pupmod::master::log_level: INFO
+
+classes:
+  - 'simp::server'
+  - 'simp::puppetdb'

--- a/environments/puppet/data/scenarios/CentOS/8/simp.yaml
+++ b/environments/puppet/data/scenarios/CentOS/8/simp.yaml
@@ -1,0 +1,3 @@
+---
+# TCP Wrappers was removed in version 8.
+simp_options::tcpwrappers: false

--- a/environments/puppet/data/scenarios/RedHat/8/simp.yaml
+++ b/environments/puppet/data/scenarios/RedHat/8/simp.yaml
@@ -1,0 +1,3 @@
+---
+# TCP Wrappers was removed in version 8.
+simp_options::tcpwrappers: false

--- a/environments/puppet/hiera.yaml
+++ b/environments/puppet/hiera.yaml
@@ -35,4 +35,7 @@ hierarchy:
   - name: SIMP specific data - Please do not modify
     paths:
     - "simp_config_settings.yaml"
+    - "scenarios/%{facts.os.family}/%{::simp_scenario}.yaml"
+    - "scenarios/%{facts.os.name}/%{facts.os.release.full}/%{::simp_scenario}.yaml"
+    - "scenarios/%{facts.os.name}/%{facts.os.release.major}/%{::simp_scenario}.yaml"
     - "scenarios/%{::simp_scenario}.yaml"


### PR DESCRIPTION
- added release versions for scenarioes and defaulted tcpwrappers to
  false for simp scenario for el8.
- added a template for puppet.your.domain.yaml for el8 in which
  tcpwrappers is set to false.  Updated the build script to
  copy it to environments/puppet/data/hosts/puppet.your.domain.yaml
  if building for el8 and remove it otherwise.

SIMP-5312 #close
SIMP-7057 #close
SIMP-7060 #close