### PR TITLE
(SIMP-6740) Fix 'simp::server' class inclusion

### DIFF
--- a/build/simp-environment-skeleton.spec
+++ b/build/simp-environment-skeleton.spec
@@ -1,6 +1,6 @@
 Summary: The SIMP Environment Skeleton
 Name: simp-environment-skeleton
-Version: 7.1.3
+Version: 7.1.4
 Release: 0
 # The entire source code is Apache License 2.0 except the following, which are
 # OpenSSL:

--- a/build/simp-environment-skeleton.spec
+++ b/build/simp-environment-skeleton.spec
@@ -80,6 +80,10 @@ cp -r environments/* %{buildroot}/%{prefix}
 %attr(0755,-,-) %{prefix}/secondary/FakeCA/usergen_nopass.sh
 
 %changelog
+* Wed Aug 26 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.1.4-0
+- Ensure that the server hieradata defaults have 'simp::server' in the
+  'simp::classes' array. Otherwise, it will never get picked up.
+
 * Wed Jun 22 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.1.3-0
 - Replace `classes` with `simp::classes` and `simp::server::classes` as
   appropriate in example Hiera YAML files.

--- a/environments/puppet/data/hosts/pe-puppet.your.domain.yaml
+++ b/environments/puppet/data/hosts/pe-puppet.your.domain.yaml
@@ -41,5 +41,5 @@ simp::server::allow_simp_user: true
 rsyslog::udp_server: true
 rsyslog::udp_listen_address: '127.0.0.1'
 
-simp::server::classes:
+simp::classes:
   - 'simp::server'

--- a/environments/puppet/data/hosts/puppet.your.domain.yaml
+++ b/environments/puppet/data/hosts/puppet.your.domain.yaml
@@ -58,6 +58,8 @@ rsyslog::udp_listen_address: '127.0.0.1'
 # puppetserver messages regarding node compile times, etc...
 # pupmod::master::log_level: INFO
 
-simp::server::classes:
+simp::classes:
   - 'simp::server'
+
+simp::server::classes:
   - 'simp::puppetdb'


### PR DESCRIPTION
- Ensure that the server hieradata defaults have 'simp::server' in the
  'simp::classes' array. Otherwise, it will never get picked up.

SIMP-6740 #comment Fix 'simp::server' class inclusion