### PR TITLE
(SIMP-8616) Use firewalld by default

### DIFF
--- a/build/simp-environment-skeleton.spec
+++ b/build/simp-environment-skeleton.spec
@@ -1,7 +1,7 @@
 Summary: The SIMP Environment Skeleton
 Name: simp-environment-skeleton
-Version: 7.1.4
-Release: 0
+Version: 7.2.0
+Release: 1
 # The entire source code is Apache License 2.0 except the following, which are
 # OpenSSL:
 #  * environments/secondary/FakeCA/CA
@@ -81,6 +81,10 @@ cp -r environments/* %{buildroot}/%{prefix}
 %attr(0755,-,-) %{prefix}/secondary/FakeCA/usergen_nopass.sh
 
 %changelog
+* Wed Nov 04 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.2.0-1
+- Ensure that firewalld is used by default in the applicable SIMP scenarios.
+- Bump the Release to '1' in the RPM spec file since this is stable.
+
 * Tue Sep 01 2020 Liz Nemsick <lnemsick.simp@gmail.com> - 7.1.4-0
 - Fixed a bug in which the FakeCA CA script was not executable.
 

--- a/environments/puppet/data/hosts/pe-puppet.your.domain.yaml
+++ b/environments/puppet/data/hosts/pe-puppet.your.domain.yaml
@@ -18,6 +18,7 @@ simp_apache::ssl::sslverifyclient: 'none'
 simp_options::auditd: true
 simp_options::clamav: true
 simp_options::firewall: true
+iptables::use_firewalld: true
 simp_options::haveged: true
 simp_options::logrotate: true
 simp_options::pam: true

--- a/environments/puppet/data/hosts/puppet.your.domain.yaml
+++ b/environments/puppet/data/hosts/puppet.your.domain.yaml
@@ -31,6 +31,7 @@ puppetdb::master::config::restart_puppet: false
 simp_options::auditd: true
 simp_options::clamav: true
 simp_options::firewall: true
+iptables::use_firewalld: true
 simp_options::haveged: true
 simp_options::logrotate: true
 simp_options::pam: true

--- a/environments/puppet/data/scenarios/simp.yaml
+++ b/environments/puppet/data/scenarios/simp.yaml
@@ -28,6 +28,7 @@ simp::scenario: 'simp'
 simp_options::auditd: true
 simp_options::clamav: true
 simp_options::firewall: true
+iptables::use_firewalld: true
 simp_options::haveged: true
 simp_options::logrotate: true
 simp_options::pam: true


### PR DESCRIPTION
Fixed:
  - Bump the Release to '1' in the RPM spec file since this is stable.
Changed:
  - Ensure that firewalld is used by default in the applicable SIMP scenarios.

SIMP-8616 #close