### PR TITLE
(SIMP-9264) Minor updates to puppet and secondary env files

### DIFF
--- a/build/simp-environment-skeleton.spec
+++ b/build/simp-environment-skeleton.spec
@@ -1,6 +1,6 @@
 Summary: The SIMP Environment Skeleton
 Name: simp-environment-skeleton
-Version: 7.2.0
+Version: 7.2.1
 Release: 1
 # The entire source code is Apache License 2.0 except the following, which are
 # OpenSSL:
@@ -81,6 +81,11 @@ cp -r environments/* %{buildroot}/%{prefix}
 %attr(0755,-,-) %{prefix}/secondary/FakeCA/usergen_nopass.sh
 
 %changelog
+* Tue Feb 02 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 7.2.1-1
+- Removed the obsolete `simp_options::clamav` setting from all hieradata
+  files.
+- Updated the FakeCA README.
+
 * Wed Nov 04 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.2.0-1
 - Ensure that firewalld is used by default in the applicable SIMP scenarios.
 - Bump the Release to '1' in the RPM spec file since this is stable.

--- a/environments/puppet/data/hosts/pe-puppet.your.domain.yaml
+++ b/environments/puppet/data/hosts/pe-puppet.your.domain.yaml
@@ -16,7 +16,6 @@ simp_apache::ssl::sslverifyclient: 'none'
 
 ### Secure SIMP Options ###
 simp_options::auditd: true
-simp_options::clamav: true
 simp_options::firewall: true
 iptables::use_firewalld: true
 simp_options::haveged: true

--- a/environments/puppet/data/hosts/puppet.your.domain.yaml
+++ b/environments/puppet/data/hosts/puppet.your.domain.yaml
@@ -29,7 +29,6 @@ puppetdb::master::config::restart_puppet: false
 
 ### Secure SIMP Options ###
 simp_options::auditd: true
-simp_options::clamav: true
 simp_options::firewall: true
 iptables::use_firewalld: true
 simp_options::haveged: true

--- a/environments/puppet/data/scenarios/remote_access.yaml
+++ b/environments/puppet/data/scenarios/remote_access.yaml
@@ -24,7 +24,6 @@
 simp::scenario: 'remote_access'
 
 simp_options::auditd: false
-simp_options::clamav: false
 simp_options::firewall: false
 simp_options::haveged: false
 simp_options::ldap: true

--- a/environments/puppet/data/scenarios/simp.yaml
+++ b/environments/puppet/data/scenarios/simp.yaml
@@ -26,7 +26,6 @@ simp::scenario: 'simp'
 
 # SIMP scenario defaults
 simp_options::auditd: true
-simp_options::clamav: true
 simp_options::firewall: true
 iptables::use_firewalld: true
 simp_options::haveged: true

--- a/environments/puppet/data/scenarios/simp_lite.yaml
+++ b/environments/puppet/data/scenarios/simp_lite.yaml
@@ -26,7 +26,6 @@ simp::scenario: 'simp_lite'
 
 # SIMP-lite scenario defaults
 simp_options::auditd: true
-simp_options::clamav: true
 simp_options::haveged: true
 simp_options::logrotate: true
 simp_options::pam: true

--- a/environments/secondary/FakeCA/README
+++ b/environments/secondary/FakeCA/README
@@ -1,7 +1,7 @@
 These scripts can be used to act as a fake CA.
 
 Enter the hostnames of the certificates that you wish to create in the file
-'togen', one per line and run the 'gencerts.sh' script.
+'togen', one per line and run the 'gencerts_nopass.sh' script.
 
 If you wish to use alternate DNS names, separate the names with commas and no
 spaces like the following example:
@@ -9,7 +9,7 @@ spaces like the following example:
    primary.name,alt.name.1,alt.name.2,ip.addr.1,ip.addr.2
 
 To generate user certificates, add users to the 'usergen' file in the following
-format (one per line) and run the 'usergen.sh' script.
+format (one per line) and run the 'usergen_nopass.sh' script.
 
    username  email-address
 
@@ -21,3 +21,16 @@ You can set the 'KEYDIST' environment variable to change the default output
 directory for generated certificates.
 
     KEYDIST=/my/target/dir ./gencerts_nopass.sh
+
+You can pass 'auto' as a command line argument to gencerts_nopass.sh
+or usergen_nopass.sh, to use defaults when it first creates the CA.
+
+    ./gencerts_nopass.sh auto
+
+       or
+
+    ./usergen_nopass.sh atuo
+
+* Otherwise, you will be prompted for the CA-specific information the
+  first time either script is run.
+* The default values are set by the CA script.


### PR DESCRIPTION
Verified the simp-environment-skeleton RPM would install on EL8 and
that the FakeCA scripts still operate. The changes here are nits
found while reviewing files:

- Removed the obsolete `simp_options::clamav` setting from all hieradata
  files.
- Updated the FakeCA README.

SIMP-9264