### PR TITLE
(SIMP-10447) Disable PuppetDB by default

### DIFF
--- a/build/simp-environment-skeleton.spec
+++ b/build/simp-environment-skeleton.spec
@@ -1,6 +1,6 @@
 Summary: The SIMP Environment Skeleton
 Name: simp-environment-skeleton
-Version: 7.2.1
+Version: 7.3.0
 Release: 1
 # The entire source code is Apache License 2.0 except the following, which are
 # OpenSSL:
@@ -81,6 +81,12 @@ cp -r environments/* %{buildroot}/%{prefix}
 %attr(0755,-,-) %{prefix}/secondary/FakeCA/usergen_nopass.sh
 
 %changelog
+* Tue Sep 07 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.3.0-1
+- No longer configure puppetdb on the puppet server by default
+  - Added documentation in the associated hieradata file
+  - Added the necessary configuration to enable puppetdb storage of node reports
+    by default
+
 * Fri Feb 19 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 7.2.1-1
 - Add eyaml hierarchy to hiera.yaml in puppet environment template.
 

--- a/environments/puppet/data/hosts/puppet.your.domain.yaml
+++ b/environments/puppet/data/hosts/puppet.your.domain.yaml
@@ -17,16 +17,6 @@ simp_apache::ssl::sslverifyclient: 'none'
 # Make this server a puppetserver
 pupmod::enable_puppet_master: true
 
-# The service name of the Puppet Server service for use with PuppetDB
-#
-# TODO: This should probably be a Fact
-puppetdb::master::config::puppet_service_name: 'puppetserver'
-
-puppetdb::globals::version: 'latest'
-
-# Let pupmod::master::base handle this.
-puppetdb::master::config::restart_puppet: false
-
 ### Secure SIMP Options ###
 simp_options::auditd: true
 simp_options::firewall: true
@@ -60,6 +50,3 @@ rsyslog::udp_listen_address: '127.0.0.1'
 
 simp::classes:
   - 'simp::server'
-
-simp::server::classes:
-  - 'simp::puppetdb'


### PR DESCRIPTION
- No longer configure puppetdb on the puppet server by default
  - Added documentation in the associated hieradata file
  - Added the necessary configuration to enable puppetdb storage of node reports
    by default

SIMP-10447 #close