### PR TITLE
Remove references to archived SIMP modules

### DIFF
--- a/environments/puppet/data/hosts/pe-puppet.your.domain.yaml
+++ b/environments/puppet/data/hosts/pe-puppet.your.domain.yaml
@@ -24,7 +24,6 @@ simp_options::pam: true
 simp_options::pki: simp
 simp_options::stunnel: true
 simp_options::syslog: true
-simp_options::tcpwrappers: true
 
 # Allow the backup SIMP user, local only to this system
 simp::server::allow_simp_user: true

--- a/environments/puppet/data/hosts/puppet.your.domain.yaml
+++ b/environments/puppet/data/hosts/puppet.your.domain.yaml
@@ -27,7 +27,6 @@ simp_options::pam: true
 simp_options::pki: simp
 simp_options::stunnel: true
 simp_options::syslog: true
-simp_options::tcpwrappers: true
 
 # Allow the backup SIMP user, local only to this system
 simp::server::allow_simp_user: true

--- a/environments/puppet/data/scenarios/remote_access.yaml
+++ b/environments/puppet/data/scenarios/remote_access.yaml
@@ -33,6 +33,5 @@ simp_options::pki: simp
 simp_options::sssd: true
 simp_options::stunnel: false
 simp_options::syslog: false
-simp_options::tcpwrappers: false
 simp_options::ipsec: false
 simp_options::kerberos: false

--- a/environments/puppet/data/scenarios/simp.yaml
+++ b/environments/puppet/data/scenarios/simp.yaml
@@ -35,7 +35,6 @@ simp_options::pki: simp
 simp_options::sssd: true
 simp_options::stunnel: true
 simp_options::syslog: true
-simp_options::tcpwrappers: true
 
 # This setting is turned off by default because use of LDAP is not
 # required

--- a/environments/puppet/data/scenarios/simp_lite.yaml
+++ b/environments/puppet/data/scenarios/simp_lite.yaml
@@ -40,7 +40,6 @@ simp_options::ldap: false
 
 # These settings explicitly turned off
 simp_options::firewall: false
-simp_options::tcpwrappers: false
 
 # Options that are not suggested to be turned on by default:
 simp_options::ipsec: false


### PR DESCRIPTION
Remove all references to the following archived modules: chkrootkit, hirs_provisioner, incron, network, rkhunter, simp_bolt, simp_ipa, simp_openldap, simp_pki_service, sudosh, tcpwrappers, tpm, xinetd

This includes removal from metadata.json dependencies, .fixtures.yml, Puppetfiles, manifests, spec tests, hiera data, and acceptance tests as applicable.